### PR TITLE
when a user was linked to a staff member by the dropdown it wasn't be…

### DIFF
--- a/app/Http/Livewire/MemberCard.php
+++ b/app/Http/Livewire/MemberCard.php
@@ -63,6 +63,7 @@ class MemberCard extends Component
     public function updateLinkedStaffMember() {
         $this->staffLinkedToMember = [(int) $this->linkedStaffMemberId];
         $this->staffNamesLinkedToMember = $this->staffMembers[(int) $this->linkedStaffMemberId];
+        $this->multipleStaffLinked = false;
         $this->emit('memberStaffLinkUpdated', (int) $this->linkedStaffMemberId, $this->memberId);
     }
 


### PR DESCRIPTION
…ing seen by the too many staff linked warning.